### PR TITLE
remove integration specific email

### DIFF
--- a/edx_proctoring_proctortrack/backends/proctortrack_rest.py
+++ b/edx_proctoring_proctortrack/backends/proctortrack_rest.py
@@ -16,7 +16,6 @@ class ProctortrackBackendProvider(BaseRestProctoringProvider):
     verbose_name = 'Proctortrack'
     tech_support_email = 'support@verificient.com'
     learner_notification_from_email = 'no-reply@verificient.com'
-    integration_specific_email = 'proctortrack-support@edx.org'
     tech_support_phone = '+1 844-753-2020'
     base_url = 'https://testing.verificient.com'
     npm_module = 'edx-proctoring-proctortrack'


### PR DESCRIPTION
Hello,

We would like to remove the edX specific email stored in `integration_specific_email` and instead store it on edX's side. 

If you're interested, the corresponding edx-proctoring pull request is https://github.com/edx/edx-proctoring/pull/560.

Thanks!