### PR TITLE
Remove reaching into the internals of the edx-rest-api-client class

### DIFF
--- a/edx_proctoring_proctortrack/backends/proctortrack_rest.py
+++ b/edx_proctoring_proctortrack/backends/proctortrack_rest.py
@@ -42,5 +42,4 @@ class ProctortrackBackendProvider(BaseRestProctoringProvider):
         client_secret: provided by backend service
         """
         super(ProctortrackBackendProvider, self).__init__(**kwargs)
-        self.session.oauth_uri = '/edx/oauth2/access_token'
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     url='https://github.com/joshivj/edx-proctoring-proctortrack',
     license="Apache-2.0",
     keywords='Proctortrack edx',
-    version='1.0.5',
+    version='1.1.0',
     packages=[
         'edx_proctoring_proctortrack',
     ],


### PR DESCRIPTION
This wasn't meant to be overridable

Should make this package compatible with edx-rest-api-client v2.0.0

JIRA:PROD-1195