### PR TITLE
Update max retries from 5 to 2

### DIFF
--- a/edx_proctoring_proctortrack/static/proctortrack_custom.js
+++ b/edx_proctoring_proctortrack/static/proctortrack_custom.js
@@ -29,7 +29,7 @@ var checkAppStatus = function () {
      * This function is used to check if the Proctortrack app is running or not.
      */
     return new Promise(function (resolve, reject) {
-        var maxFailedAttemptCount = 5;
+        var maxFailedAttemptCount = 2;
         var failedAttemptCount = 0;
 
         var attemptConnection = function () {


### PR DESCRIPTION
We would like to decrease the number of retries from 5 to 2 in order to reduce the amount of time between Proctortrack being down and edX notifying a learner that they are in an error state.