### PR TITLE
retry 5 times within provided timeout

### DIFF
--- a/edx_proctoring_proctortrack/static/proctortrack_custom.js
+++ b/edx_proctoring_proctortrack/static/proctortrack_custom.js
@@ -78,7 +78,7 @@ class PTProctoringServiceHandler {
     }
 
     onPing(timeout) {
-        return checkAppStatus(turnout);
+        return checkAppStatus(timeout);
     }
 }
 

--- a/edx_proctoring_proctortrack/static/proctortrack_custom.js
+++ b/edx_proctoring_proctortrack/static/proctortrack_custom.js
@@ -24,13 +24,14 @@ var closePTApp = function () {
     });
 };
 
-var checkAppStatus = function () {
+var checkAppStatus = function (timeout) {
     /**
      * This function is used to check if the Proctortrack app is running or not.
      */
     return new Promise(function (resolve, reject) {
         var maxFailedAttemptCount = 5;
         var failedAttemptCount = 0;
+        var retryInterval = Math.floor(timeout / maxFailedAttemptCount);
 
         var attemptConnection = function () {
             var xhr = new XMLHttpRequest();
@@ -46,7 +47,7 @@ var checkAppStatus = function () {
                 } else {
                     failedAttemptCount += 1;
                     if (failedAttemptCount < maxFailedAttemptCount) {
-                        setTimeout(attemptConnection, 30 * 1000);
+                        setTimeout(attemptConnection, retryInterval);
                     } else {
                         reject(Error("Failed to check if proctoring has started."));
                     }
@@ -55,7 +56,7 @@ var checkAppStatus = function () {
             xhr.onerror = function () {
                 failedAttemptCount += 1;
                 if (failedAttemptCount < maxFailedAttemptCount) {
-                    setTimeout(attemptConnection, 30 * 1000);
+                    setTimeout(attemptConnection, retryInterval);
                 } else {
                     reject(Error("Proctortrack app is not running."));
                 }
@@ -76,8 +77,8 @@ class PTProctoringServiceHandler {
         return closePTApp();
     }
 
-    onPing() {
-        return checkAppStatus();
+    onPing(timeout) {
+        return checkAppStatus(turnout);
     }
 }
 

--- a/edx_proctoring_proctortrack/static/proctortrack_custom.js
+++ b/edx_proctoring_proctortrack/static/proctortrack_custom.js
@@ -24,7 +24,7 @@ var closePTApp = function () {
     });
 };
 
-var checkAppStatus = function (timeout) {
+var checkAppStatus = function (timeout=150000) {
     /**
      * This function is used to check if the Proctortrack app is running or not.
      */


### PR DESCRIPTION
This aims to fix an issue where if the timeout on the edx side is less than the total time it takes for `checkAppStatus` to resolve. This allows us to guarantee the errors are reported back to the edx platform for logging and allows us to adjust the time out with configuration instead of code changes.