### PR TITLE
chore: update edx-proctoring version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/joshivj/edx-proctoring-proctortrack#readme",
   "dependencies": {
-    "@edx/edx-proctoring": "^1.5.0"
+    "@edx/edx-proctoring": "^3.8.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
As it turns out this library pulls its own version of edx-proctoring which is not the same version that is installed in the LMS. So, the recent changes that added an error argument to the message interface was not being used.

~Leaving this is a draft right now while we assess risk/reward of merging this before an important partner exam.~ we have decided to merge this