### PR TITLE
make edx-proctoring a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/joshivj/edx-proctoring-proctortrack/issues"
   },
   "homepage": "https://github.com/joshivj/edx-proctoring-proctortrack#readme",
-  "dependencies": {
+  "peerDependencies": {
     "@edx/edx-proctoring": "^4.8.1"
   },
   "publishConfig": {


### PR DESCRIPTION
This should fix the need for us to update this file every time we make a minor change to our library. Whatever version is installed in edx-platform will just get used so long as it is compatible.