### PR TITLE
Add support for django 4.2

### DIFF
--- a/edx_proctoring_proctortrack/backends/proctortrack_rest.py
+++ b/edx_proctoring_proctortrack/backends/proctortrack_rest.py
@@ -2,7 +2,7 @@
 Base implementation of a REST backend, following the API documented in
 docs/backends.rst
 """
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from edx_proctoring.backends.rest import BaseRestProctoringProvider
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     url='https://github.com/joshivj/edx-proctoring-proctortrack',
     license="Apache-2.0",
     keywords='Proctortrack edx',
-    version='1.2.1',
+    version='1.2.2',
     packages=[
         'edx_proctoring_proctortrack',
     ],


### PR DESCRIPTION
Hi @anupdhabarde,

ugettext is removed in Django 4.0 https://docs.djangoproject.com/en/4.2/releases/4.0/#features-removed-in-4-0 and is replaced with gettext.

Can we also have a new release after this PR is merged?

Thanks,